### PR TITLE
Allow applet bcbio-run-workflow to have VIEW access to all Projects that the user running the app can access.

### DIFF
--- a/bcbio-run-workflow/dxapp.json
+++ b/bcbio-run-workflow/dxapp.json
@@ -63,6 +63,7 @@
   },
   "access": {
     "project": "CONTRIBUTE",
+    "allProjects": "VIEW",
     "network": [
       "*"
     ]


### PR DESCRIPTION
This change is to allow the job that runs bcbio-run-workflow to directly access data among the parent project and VIEW data in all projects that the user who run the job can access.
All projects includes reference genome project.